### PR TITLE
Fixed CMD of Dockerfile_api

### DIFF
--- a/Dockerfile_api
+++ b/Dockerfile_api
@@ -65,4 +65,4 @@ COPY . .
 HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
 EXPOSE 5000
 
-CMD [".venv/bin/activate", "&&", ".venv/bin/python", "app.py", "--only_api"]
+CMD ["sh", "-c", ". .venv/bin/activate && .venv/bin/python app.py --only_api"]


### PR DESCRIPTION
Fix for: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: ".venv/bin/activate": permission denied: unknown